### PR TITLE
Documentacionen 7 prueba solución fallo graphviz

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -19,7 +19,7 @@ jobs:
       run: gem install asciidoctor asciidoctor-diagram
 
     - name: Install Graphviz
-      run: sudo apt-get install graphviz
+      run: sudo apt-get install graphviz && sudo apt-get upgrade graphviz
 
     - name: Set up Node.js
       uses: actions/setup-node@v1

--- a/docs/src/07_deployment_view.adoc
+++ b/docs/src/07_deployment_view.adoc
@@ -1,3 +1,5 @@
+ifndef::imagesdir[:imagesdir: ../images]
+
 [[section-deployment-view]]
 
 == Deployment View
@@ -57,28 +59,27 @@ These workflows help maintain the project’s quality, ensure that the team rema
 [plantuml,"Docker Container Setup",png]
 ----
 @startuml
-rectangle "Docker compose" {
-    rectangle "App's Docker Container"  {
+package "Docker compose" {
+    package "App's Docker Container" {
         node "Java Spring Boot App (.jar)" as App
         database "Web Server (Embedded)" as WebServer
     }
 
-    rectangle "MySQL Server Container" {
+    package "MySQL Server Container" {
         database "MySQL Server" as MySQL
     }
 
-    rectangle "Prometheus Container" {
+    package "Prometheus Container" {
         database "Prometheus" as Prometheus
     }
 
-    rectangle "Grafana Container" {
+    package "Grafana Container" {
         node "Grafana" as Grafana
     }
-
 }
+
 cloud "LLM API" as LLM
 cloud "Wikidata API" as API
-
 
 App --> MySQL : Store game data
 MySQL --> App : Fetch game data
@@ -88,6 +89,7 @@ App ..> WebServer : Server application
 Prometheus --> App : Collect metrics
 Grafana --> Prometheus : Visualize metrics
 @enduml
+
 ----
 
 .Explanation:


### PR DESCRIPTION
Probé si el archivo .png se generaba con el documento del año pasado para el aprtado 7 y tampoco lo es capaz de generar al ejecutar npm run build. Por lo que algun cambio en las dependencias/plugins del pom entiendo que ha producido el fallo.